### PR TITLE
Index: Fix CC0 hyperlink

### DIFF
--- a/index.html
+++ b/index.html
@@ -1184,7 +1184,7 @@ w.postMessage command
 
 <p>For the SocialCalc spreadsheet engine, Socialtext designed the <a rel="noreferrer" href="https://www.socialtext.net/open/cpal">Common Public Attribution License</a>. By enabling users to request a copy of the original JavaScript source code they're running from server operators, we encouraged operators to contribute back their code.</p>
 
-<p>As for the server-side code of EtherCalc, I have dedicated it into the <a rel="noreferrer" href="creativecommons.org/publicdomain/zero/1.0">public domain</a> to encourage integration with content hosting systems, so anybody can set up a collaborative spreadsheet easily. Many people have indeed done so, and you're welcome to join us, too!</p>
+<p>As for the server-side code of EtherCalc, I have dedicated it into the <a rel="noreferrer" href="https://creativecommons.org/publicdomain/zero/1.0">public domain</a> to encourage integration with content hosting systems, so anybody can set up a collaborative spreadsheet easily. Many people have indeed done so, and you're welcome to join us, too!</p>
 </section>
       </article>
 <img width="50%" style="max-width:34%; margin-top: 50px; margin-left: 33%" alt="唐鳳 Audrey Tang" src="ethercalc.tw.signature.png">


### PR DESCRIPTION
Previously the CC0 link resolves to <https://ethercalc.net/creativecommons.org/publicdomain/zero/1.0> and points to an Error 404 Not Found page due to the missing `http(s)://`, this patch fixes it.

Signed-off-by: 林博仁 &lt;<Buo.Ren.Lin@gmail.com>&gt;